### PR TITLE
Do not lose proxy settings when invoking apt.

### DIFF
--- a/scripts/ctool
+++ b/scripts/ctool
@@ -108,6 +108,8 @@ apt_install() {
 
 apt_get() {
     local ret=""
+    [ "$(id -u)" = "0" ] ||
+        { error "Must be root for apt-get"; return 1; }
     if [ "$1" != "update" ] && ! $_APT_UPDATED; then
         debug 1 "updating apt"
         apt_get update >/dev/null || {
@@ -119,7 +121,7 @@ apt_get() {
     fi
     local emd=""
     command -v eatmydata >/dev/null 2>&1 && emd="eatmydata"
-    set -- sudo DEBIAN_FRONTEND=noninteractive $emd \
+    set -- env DEBIAN_FRONTEND=noninteractive $emd \
         apt-get --quiet --no-install-recommends --assume-yes "$@"
     debug 1 "Installing depends: $*"
     "$@" </dev/null


### PR DESCRIPTION
I noticed that the http_proxy settings were not getting passed through
to apt-get (run-container --install=package1), and thus the proxy
not getting used.  This was due to the apt_get function invoking
sudo.  That was not necessary as the 'install_packages' function
already ensured that it was running as root (--user=root).

So.. the easy fix is to just *not* use sudo.  It uses env instead so
that the debug statement can represent that environment var was used.