### PR TITLE
build-package: default to debuild with -nc.

### DIFF
--- a/scripts/build-package
+++ b/scripts/build-package
@@ -176,7 +176,7 @@ main() {
     genchanges_v="$_RET"
 
     if [ $# -eq 0 ]; then
-        set -- -d -S ${genchanges_v}
+        set -- -d -S -nc ${genchanges_v}
     elif [ -n "${genchanges_v}" ]; then
         set -- "$@" ${genchanges_v}
     fi


### PR DESCRIPTION
If not provided with any arguments, build-package would build a source
package using '-d' (no-check-builddeps).
The change here is just to add '-nc' as well.
Without this change, the clean target will be invoked and may fail
if that target used a missing builddep.

The invocation of debuild is done in a clean git worktree in a
temporary directory, so there is no need to clean first.