### PR TITLE
ctool: launch containers with 'lxc launch ... </dev/null'

### DIFF
--- a/scripts/ctool
+++ b/scripts/ctool
@@ -235,7 +235,7 @@ run_container() {
         source="ubuntu-daily:${source}"
     fi
     local out=""
-    out=$(lxc launch "$source" "$name" 2>&1) || {
+    out=$(lxc launch "$source" "$name" 2>&1 </dev/null) || {
         errorrc "failed lxc launch $source $name: $out";
         return
     }


### PR DESCRIPTION
Since LXD version 3.17 the lxc command is able to read the container
configuration as YAML from stdin on `lxc init` and `lxc launch`. This
broke the ctool script, which is supposed to take a script from stdin,
but stdin is now consumed by lxc. To avoid this this commit adds a
</dev/null when running `lxc launch`.