### PR TITLE
ctool: ensure there are no colons in the 'git clone' target directory

### DIFF
--- a/scripts/ctool
+++ b/scripts/ctool
@@ -688,7 +688,8 @@ parse_giturl() {
         lp:*@*|*://*@*)
             repo="${giturl%@*}"
             while [ "${repo%/}" != "${repo}" ]; do repo=${repo%/}; done
-            target=${repo##*/}
+            target=${repo#*:}
+            target=${target##*/}
             commitish=${giturl##*@};;
         *)
             repo="$giturl"


### PR DESCRIPTION
Given a git url, ctool clones the repository to a target directory named
as the url with everything up the last '/' removed, so:

  https://github.com/user/repo is cloned to 'repo'
  lp:~user/repo is cloned to 'repo'

This doesn't work when the url doesn't contain a '/', something that can
happen when using the 'lp:' shorthand, e.g.

  lp:project is cloned to 'lp:project'

This happens to break the virtualenv Python module in some test
environments because of [1]. This commit constructs the `git clone` target
directory first by trimming the git url up to the first ':', and then
up to the last '/', accounting for 'slashless' URLs.

[1] https://github.com/pypa/virtualenv/issues/395