### PR TITLE
Feature/execute improvements

### DIFF
--- a/scripts/ctool
+++ b/scripts/ctool
@@ -472,9 +472,10 @@ is_done_other() {
 
 
 execute() {
-    call_in_env "$@" && return "$_RET"
+    call_in_env --def-cmd="${SHELL:-/bin/sh}" "$@" && return "$_RET"
     set -- "${_RET_CMD[@]}"
     local dir="${_RET_DIR}"
+    debug 1 "[$USER${container:+@${container}}:${dir:-$PWD}]: running $*"
     ( set -e; cd ~; cd "${dir:-.}"; "$@" )
 }
 
@@ -549,7 +550,7 @@ call_in_env() {
     #   _RET_CMD      : an array of the command with --container/--dir flags removed.
     #   _RET          : if rc was 0, this is the return value of the command executed.
     local cur_user="" cur_container="${_container:-}" self="false"
-    local container="" user="" dir="" need_stdin=false
+    local container="" user="" dir="" need_stdin=false defcmd=""
     local -a args=( )
     _RET_CMD=( )
     _RET="1"
@@ -562,6 +563,7 @@ call_in_env() {
             -u|--user) user="$next"; shift;;
             --user=*) user="${cur#*=}";;
             -d|--dir) dir="$next"; shift;;
+            --def-cmd=*) defcmd="${cur#*=}";;
             --dir=*) dir=${cur#*=};;
             --need-stdin) need_stdin=true;;
             --) shift; break;;
@@ -573,6 +575,8 @@ call_in_env() {
 
     [ "${#args[@]}" -ne 0 ] && [ "${args[0]}" = "self" ] &&
         { self=true; args=( "${args[@]:1}" ); }
+
+    [ "${#args[@]}" -eq 0 ] && [ -n "$defcmd" ] && args=( "$defcmd" )
 
     cur_user="$(id -un)"
     case "${container}:${user}" in
@@ -617,7 +621,7 @@ call_in_env() {
         fi
     fi
 
-    local qcmd="$*"
+    local qcmd="$* ${args[*]}"
     command -v shell-quote >/dev/null 2>&1 &&
         qcmd=$(shell-quote "$@" "${args[@]}")
 

--- a/scripts/ctool
+++ b/scripts/ctool
@@ -17,7 +17,7 @@ errorrc() { local r=$?; error "$@" "ret=$r"; return $r; }
 
 Usage_main() {
     cat <<EOF
-Usage: ${0##*/} mode [options]
+Usage: ${0##*/} [global options] mode [options]
 
   A convenient frontend to lxc containers.
 
@@ -972,6 +972,11 @@ git_import() {
 delete_container() {
     lxc delete --force "$1"
 }
+
+while [ "${1:-}" = "-v" -o "${1:-}" = "--verbose" ]; do
+    VERBOSITY=$((VERBOSITY+1));
+    shift
+done
 
 case "${1:-}" in
     self) shift; "$@";;

--- a/scripts/ctool
+++ b/scripts/ctool
@@ -27,7 +27,7 @@ Usage: ${0##*/} [global options] mode [options]
   subcommands:
    run-container                [--destroy] [--name=] source [command]
    wait-for-boot [--container=]
-   execute       [--container=] [--dir=] [--user=] command
+   exec|execute  [--container=] [--dir=] [--user=] [command]
    add-user      [--container=] user
 
    git-export    [--dirty]
@@ -983,6 +983,7 @@ case "${1:-}" in
     install-deps|run-container|wait-for-boot|add-user|\
     git-export|git-import|git-clone|git-push-clone|execute)
         _n="${1//-/_}"; shift; "$_n" "$@";;
+    exec) shift; execute "$@";;
     *) bad_Usage main; exit;;
 esac
 


### PR DESCRIPTION
Whats here is:
  * make 'ctool exec' the same as 'ctool execute'.  Just shorter and nicer.
  * Get leading '-v' flags parsed "globally" so that verbosity gets increased (most useful for debugging 'execute', which is slightly different than other sub-commands)
  * default to ${SHELL:-/bin/sh} as the command to execute for execute.