### PR TITLE
Fix add-user to work without --container.

### DIFF
--- a/scripts/ctool
+++ b/scripts/ctool
@@ -490,7 +490,7 @@ EOF
 }
 
 add_user() {
-    call_in_env self "${FUNCNAME[0]}" "$@" && return "$_RET"
+    call_in_env self "${FUNCNAME[0]}" --user=root "$@" && return "$_RET"
     set -- "${_RET_CMD[@]}"
 
     local short_opts="hv"


### PR DESCRIPTION
This makes ctool do the right thing for add-user if user is not root.

    $ ctool add-user -v testsm1
    adding user testsm1
    $ sudo `which ctool` add-user -v testsm2
    adding user testsm2
    $ ctool add-user -v --container=b1 testb1sm1
    [b1] adding user testb1sm1

    $ ctool execute --user=testsm2 -- sh -c 'whoami; pwd'
    testsm2
    /home/testsm2
    $ ctool execute --container=b1 --user=testb1sm1 -- sh -c 'whoami; pwd'
    testb1sm1
    /home/testb1sm1