### PR TITLE
log2dch: redact and lp-to-git-users from debian changelog

### DIFF
--- a/scripts/log2dch
+++ b/scripts/log2dch
@@ -4,6 +4,8 @@ VERBOSITY=0
 TEMP_D=""
 COMMIT_URL=${COMMIT_URL:-https://git.launchpad.net/cloud-init/commit/?id=}
 
+FILTER_LIST=( "lp-to-git-user" )
+
 error() { echo "$@" 1>&2; }
 fail() { local r=$?;  [ $r -eq 0 ] && r=1; failrc "$r" "$@"; }
 failrc() { local r=$1; shift; [ $# -eq 0 ] || error "$@"; exit "$r"; }
@@ -18,6 +20,7 @@ Usage: ${0##*/} [ options ] [input-file]
    options:
       --vcs VCS         which log format is this ('git', 'auto', 'bzr')
                         default: auto
+      --skip-bugs       Do not print bug info
       --trello          output in markdown for checklist items in trello
       --hackmd          output markdown formated for hackmd.io
       --commit-url=URL  use a different commit url.
@@ -67,11 +70,13 @@ debug() {
 bzr_log_to_dch() {
     local line="" commit="" bugs="" bug=""
     local func="${1:-print_dch}"
+    local skip_bugs="${2:-false}"
     while :; do
         read line || break
         case "$line" in
             revno:\ *)
                 if [ -n "$commit" ]; then
+	            $skip_bugs && bugs=""
                     $func "$commit" "$subject" "$author" "$bugs"
                 fi
                 commit=${line#*: }
@@ -89,6 +94,7 @@ bzr_log_to_dch() {
         esac
     done
     if [ -n "$commit" ]; then
+	$skip_bugs && bugs=""
         $func "$commit" "$subject" "$author" "$bugs"
     fi
 }
@@ -112,6 +118,11 @@ print_hackmd() {
     if [[ $buf == 'tests:'* ]]; then
 	buf="~~NOTEST ${buf}~~"
     fi
+    for filter in "${FILTER_LIST[@]}"; do
+        if [[ "$subject" != "${subject/$filter//}" ]]; then
+            return  # skip echo because our filter string matched
+	fi
+    done
     echo "- $buf"
 }
 
@@ -126,6 +137,11 @@ print_trello() {
         buf="${buf:+${buf} }[${bug}](http://pad.lv/$bug)"
     done
     buf="${buf:+${buf} }$subject"
+    for filter in "${FILTER_LIST[@]}"; do
+        if [[ "$subject" != "${subject/$filter//}" ]]; then
+            return  # skip echo because our filter string matched
+	fi
+    done
     echo "$buf"
 }
 
@@ -136,9 +152,14 @@ print_dch() {
     #( for i in ${bugs}; do echo ${i%,}; done); return
     aname=${author% <*}
     case "$aname" in
-        Chad\ Smith|Ryan\ Harper|Scott\ Moser|Daniel\ Watkins) aname="";;
+        Chad\ Smith|Ryan\ Harper|Daniel\ Watkins) aname="";;
     esac
     abugs="${aname:+ [${aname}]}${bugs:+ (LP: ${bugs})}"
+    for filter in "${FILTER_LIST[@]}"; do
+        if [[ "$subject" != "${subject/$filter//}" ]]; then
+            return  # skip echo because our filter string matched
+	fi
+    done
     if [ $((${#subject}+${#abugs})) -le $((ll-${#indent})) ]; then
         echo "${indent}${subject}${abugs}"
     elif [ ${#subject} -ge $((ll-${#indent})) ]; then
@@ -160,11 +181,13 @@ print_dch() {
 git_log_to_dch() {
     local line="" commit="" bugs=""
     local func=${1:-print_dch}
+    local skip_bugs=${2:-false}
     while :; do
         read line || break
         case "$line" in
             commit\ *)
                 if [ -n "$commit" ]; then
+	            $skip_bugs && bugs=""
                     "$func" "$commit" "$subject" "$author" "$bugs"
                 fi
                 commit=${line#commit }
@@ -178,6 +201,7 @@ git_log_to_dch() {
         esac
     done
     if [ -n "$commit" ]; then
+	$skip_bugs && bugs=""
         $func "$commit" "$subject" "$author" "$bugs"
     fi
 }
@@ -189,19 +213,20 @@ assert_temp_d() {
 
 main() {
     local short_opts="ht:v"
-    local long_opts="commit-url:,hackmd,help,trello,vcs:,verbose"
+    local long_opts="commit-url:,hackmd,help,skip-bugs,trello,vcs:,verbose"
     local getopt_out=""
     getopt_out=$(getopt --name "${0##*/}" \
         --options "${short_opts}" --long "${long_opts}" -- "$@") &&
         eval set -- "${getopt_out}" ||
         { bad_Usage; return; }
 
-    local cur="" next="" vcs="auto" input="-" omode="dch"
+    local cur="" next="" vcs="auto" input="-" omode="dch" skip_bugs=false
 
     while [ $# -ne 0 ]; do
         cur="$1"; next="$2";
         case "$cur" in
             -h|--help) Usage ; exit 0;;
+               --skip-bugs) skip_bugs=true;;
                --trello) omode="trello";;
                --hackmd) omode="hackmd";;
                --commit-url) COMMIT_URL="$next";;
@@ -251,7 +276,7 @@ main() {
         *) printer="print_dch";;
     esac
     local func="${vcs}_log_to_dch"
-    "$func" "$printer"
+    "$func" "$printer" $skip_bugs
     return
 }
 

--- a/scripts/new-upstream-snapshot
+++ b/scripts/new-upstream-snapshot
@@ -36,60 +36,6 @@ options:
 EOF
 }
 
-print_commit() {
-    local subject="$1" author="$2" bugs="$3" aname="" buf="" abugs=""
-    local indent="    - " indent2="      " ll=79
-    aname=${author% <*}
-    case "$aname" in
-        # core team members do not need credit in changelog.
-        Daniel\ Watkins|Chad\ Smith|Ryan\ Harper) aname="";;
-    esac
-    abugs="${aname:+ [${aname}]}${bugs:+ (LP: ${bugs})}"
-    if [ $((${#subject}+${#abugs})) -le $(($ll-${#indent})) ]; then
-        echo "${indent}${subject}${abugs}"
-    elif [ ${#subject} -ge $(($ll-${#indent})) ]; then
-        echo "${subject}${abugs}" |
-            fmt --width=$(($ll-${#indent})) |
-            sed -e "1s/^/${indent}/; 1n;" \
-                -e 's/^[ ]*//' \
-                -e '/^[ ]*$/d' -e "s/^/$indent2/" -e 's/[ ]\+$//'
-
-    else
-        ( echo "${subject}"; echo "${abugs}" ) |
-            fmt --width=$(($ll-${#indent})) |
-            sed -e "1s/^/${indent}/; 1n;" \
-                -e 's/^[ ]*//' \
-                -e '/^[ ]*$/d' -e "s/^/$indent2/" -e 's/[ ]\+$//'
-    fi
-}
-
-git_log_to_dch() {
-    local line="" commit="" lcommit="" bugs=""
-    local skip_bugs=false
-    [ "$1" = "--skip-bugs" ] && skip_bugs=true && shift
-    while :; do
-        read line || break
-        case "$line" in
-            commit\ *)
-                $skip_bugs && bugs=""
-                if [ -n "$commit" ]; then
-                    print_commit "$subject" "$author" "$bugs"
-                fi
-                commit=${line#*: }
-                bugs=""
-                author=""
-                subject=""
-                ;;
-            Author:*) author="${line#Author: }";;
-            LP:*) bugs="${bugs:+${bugs}, }${line#*: }";;
-            "") [ -z "$subject" ] && read subject;;
-        esac
-    done
-    $skip_bugs && bugs=""
-    if [ -n "$commit" ]; then
-        print_commit "$subject" "$author" "$bugs"
-    fi
-}
 
 env_quilt() {
     local diffargs="-p ab --no-timestamps --no-index"
@@ -204,22 +150,23 @@ is_merge_commit() {
 
 main() {
     local short_opts="h:v"
-    local long_opts="help,bugs,update-patches-only,no-bugs,no-prompt,skip-branch-name-check,verbose"
+    local long_opts="help,bugs,update-patches-only,no-bugs,no-prompt,skip-branch-name-check,sru-bug,verbose"
     local getopt_out=""
     getopt_out=$(getopt --name "${0##*/}" \
         --options "${short_opts}" --long "${long_opts}" -- "$@") &&
         eval set -- "${getopt_out}" ||
         { bad_Usage; return; }
     local skip_branch_name_check="${SKIP_BRANCH_NAME_CHECK:-0}"
-    local update_patches_only=false bug_refs_in_clog=true
+    local update_patches_only=false bug_refs_in_clog=true sru_bug_fillstr="SRU_BUG_NUMBER_HERE"
 
-    local cur="" next=""
+    local cur="" next="" 
     while [ $# -ne 0 ]; do
         cur="$1"; next="$2";
         case "$cur" in
             -h|--help) Usage ; exit 0;;
                --skip-branch-name-check) skip_branch_name_check=1;;
                --update-patches-only) update_patches_only=true;;
+               --sru-bug) sru_bug_fillstr=$3; shift;;
                --no-bugs) bug_refs_in_clog=false;;
             -v|--verbose) VERBOSITY=$((${VERBOSITY}+1));;
             --) shift; break;;
@@ -287,7 +234,7 @@ main() {
         sed 's,.*~\([0-9.]*\)[.][0-9]$,~\1.1,')
     [ "${sru_ver_suff}" = "${prev_pkg_ver}" ] && sru_ver_suff=""
 
-    local sru_bug_fillstr="SRU_BUG_NUMBER_HERE" sru_bug_string="" skip_bugs=""
+    local sru_bug_string="" skip_bugs=""
     [ "${bug_refs_in_clog}" = "false" ] && skip_bugs="--skip-bugs"
     if [ -n "$sru_ver_suff" ]; then
         sru_bug_string="(LP: #$sru_bug_fillstr)"
@@ -475,18 +422,16 @@ main() {
         fail "failed git log ${prev_pkg_hash}..${from_ref}"
 
     local entries=""
-    entries=$(
-        echo "  * $new_msg${sru_bug_string:+ ${sru_bug_string}}"
-        git_log_to_dch $skip_bugs < "$gitlog") ||
-            fail "failed git_log_to_dch"
-    add_changelog_entries "$entries" "${new_pkg_ver}" || fail
+    header="  * $new_msg${sru_bug_string:+ ${sru_bug_string}}"
+    entries=`cat $gitlog | log2dch $skip_bugs`
+    add_changelog_entries "$header\n$entries" "${new_pkg_ver}" || fail
 
-    git_log_to_dch < "$gitlog" > "new-upstream-changes.txt" ||
-        fail "failed git_log_to_dch"
+    cat "$gitlog" | log2dch $skip_bugs > "new-upstream-changes.txt" ||
+        fail "failed log2dch"
 
     dch -e || fail "dch -e exited $?"
 
-    if grep -q "$sru_bug_fillstr" debian/changelog; then
+    if grep -q "SRU_BUG_NUMBER_HERE" debian/changelog; then
         echo "You did not fill in an SRU bug string.  Add one now."
         read answer
         dch -e


### PR DESCRIPTION
* Add a FILTER_LIST to log2dch to redact matching commits from changelog
* Add --skip-bugs param to log2dch so that it new-upstream-snapshot can use it
* Remove function duplication in new-upstream-snapshot to use log2dch