### PR TITLE
scripts: jenkins-get-job accepts username/password for MAAS jenkins

### DIFF
--- a/scripts/jenkins-get-job
+++ b/scripts/jenkins-get-job
@@ -28,11 +28,16 @@ def main():
     parser.add_argument(
         '--url', type=str, default=JENKINS_URL,
         help='the url for jenkins to query')
+    parser.add_argument(
+        '--username', type=str, help='the username for jenkins')
+    parser.add_argument(
+        '--password', type=str, help='the password for jenkins')
     parser.add_argument('--verbose', '-v', action='count', default=0)
     parser.add_argument('jobs', nargs='+', default=[])
     args = parser.parse_args()
 
-    server = Jenkins(args.url, timeout=60)
+    server = Jenkins(
+        args.url, timeout=60, username=args.username, password=args.password)
 
     level = (log.ERROR, log.INFO, log.DEBUG)[min(args.verbose, 2)]
     log.basicConfig(stream=sys.stderr, level=level)


### PR DESCRIPTION
MAAS jenkins requires username and password.

This branch is used in SRU testing to havest logs from the MAAS server by: https://github.com/cloud-init/ubuntu-sru/pull/77