### PR TITLE
scripts: add lp-create-bug script for bulk bug creation from files

### DIFF
--- a/scripts/lp-create-bug
+++ b/scripts/lp-create-bug
@@ -1,8 +1,5 @@
 #!/usr/bin/python3
-"""Mark the provided launchpad bugs as fix-released.
-
-Update the bug with a comment.
-"""
+"""Create bugs in launchpad for the specified project"""
 
 import argparse
 import sys
@@ -11,21 +8,26 @@ from launchpadlib.launchpad import Launchpad
 
 BUG_IMPORTANCE = ['Low', 'Wishlist', 'Medium', 'High', 'Critical']
 BUG_STATUS = ['New', 'Confirmed', 'Triaged', 'In Progress', 'Fix Committed']
+CREATE_BUG_MESSAGE_TMPL = """
+Creating a bug in {project}:
+Importance: {importance}
+Status:     {status}
+Tags:       {tags}
+Title: {title}
+
+{description}
+"""
 
 def main():
-    parser = argparse.ArgumentParser()
-
-    subject_tmpl = "Fixed in {project} version {version}."
-    comment_tmpl = (
-        "This bug is believed to be fixed in {project} in version "
-        "{version}. If this is still a problem for you, please make a "
-        "comment and set the state back to New\n\nThank you.")
+    parser = argparse.ArgumentParser(description=__doc__)
 
     parser.add_argument('--title', required=True, action='store',
                         help="Bug title string")
+    parser.add_argument('--tags', action='append', default=[],
+                        help="Specify optional tag to add to the bug.")
     parser.add_argument('--importance', action='store', default=None,
                         choices=BUG_IMPORTANCE, help="Bug importance value")
-    parser.add_argument('--status', action='store', default=None,
+    parser.add_argument('--status', action='store', default='New',
                         choices=BUG_STATUS, help="Bug status value")
     parser.add_argument('--description', action='store', required=True,
                         help="Bug description string or @file")
@@ -46,9 +48,18 @@ def main():
             description = stream.read()
     else:
         description = args.description
-    lp_bug = lp.bugs.createBug(
-        description=description, title=args.title, target=lp_project,
-        tags=['bitesize'])
+    create_args = {
+        "target": lp_project,
+        "title": args.title,
+        "description": description,
+        "tags": args.tags}
+
+    print(CREATE_BUG_MESSAGE_TMPL.format(
+        project=project_name, importance=args.importance,
+        status=args.status, **create_args))
+    if args.dry_run:
+        return
+    lp_bug = lp.bugs.createBug(**create_args)
     for task in lp_bug.bug_tasks:
         if task.bug_target_name == project_name:
             if args.importance:

--- a/scripts/lp-create-bug
+++ b/scripts/lp-create-bug
@@ -2,8 +2,6 @@
 """Create bugs in launchpad for the specified project"""
 
 import argparse
-import sys
-import re
 from launchpadlib.launchpad import Launchpad
 
 BUG_IMPORTANCE = ['Low', 'Wishlist', 'Medium', 'High', 'Critical']
@@ -18,12 +16,13 @@ Title: {title}
 {description}
 """
 
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
 
     parser.add_argument('--title', required=True, action='store',
                         help="Bug title string")
-    parser.add_argument('--tags', action='append', default=[],
+    parser.add_argument('--tag', action='append', default=[],
                         help="Specify optional tag to add to the bug.")
     parser.add_argument('--importance', action='store', default=None,
                         choices=BUG_IMPORTANCE, help="Bug importance value")
@@ -52,7 +51,7 @@ def main():
         "target": lp_project,
         "title": args.title,
         "description": description,
-        "tags": args.tags}
+        "tags": args.tag}
 
     print(CREATE_BUG_MESSAGE_TMPL.format(
         project=project_name, importance=args.importance,
@@ -67,6 +66,7 @@ def main():
             if args.status:
                 task.status = args.status
             task.lp_save()
+
 
 if __name__ == '__main__':
     main()

--- a/scripts/lp-create-bug
+++ b/scripts/lp-create-bug
@@ -1,0 +1,61 @@
+#!/usr/bin/python3
+"""Mark the provided launchpad bugs as fix-released.
+
+Update the bug with a comment.
+"""
+
+import argparse
+import sys
+import re
+from launchpadlib.launchpad import Launchpad
+
+BUG_IMPORTANCE = ['Low', 'Wishlist', 'Medium', 'High', 'Critical']
+BUG_STATUS = ['New', 'Confirmed', 'Triaged', 'In Progress', 'Fix Committed']
+
+def main():
+    parser = argparse.ArgumentParser()
+
+    subject_tmpl = "Fixed in {project} version {version}."
+    comment_tmpl = (
+        "This bug is believed to be fixed in {project} in version "
+        "{version}. If this is still a problem for you, please make a "
+        "comment and set the state back to New\n\nThank you.")
+
+    parser.add_argument('--title', required=True, action='store',
+                        help="Bug title string")
+    parser.add_argument('--importance', action='store', default=None,
+                        choices=BUG_IMPORTANCE, help="Bug importance value")
+    parser.add_argument('--status', action='store', default=None,
+                        choices=BUG_STATUS, help="Bug status value")
+    parser.add_argument('--description', action='store', required=True,
+                        help="Bug description string or @file")
+    parser.add_argument('--dry-run', action='store_true', default=False,
+                        help='only report what would be done')
+    parser.add_argument('project', action='store', default=None,
+                        help='The project to use.')
+
+    args = parser.parse_args()
+
+    lp = Launchpad.login_with(
+        "uss-tableflip lp-bug-create", 'production', version='devel')
+
+    project_name = args.project
+    lp_project = lp.projects(project_name)
+    if args.description and args.description.startswith('@'):
+        with open(args.description[1:], 'r') as stream:
+            description = stream.read()
+    else:
+        description = args.description
+    lp_bug = lp.bugs.createBug(
+        description=description, title=args.title, target=lp_project,
+        tags=['bitesize'])
+    for task in lp_bug.bug_tasks:
+        if task.bug_target_name == project_name:
+            if args.importance:
+                task.importance = args.importance
+            if args.status:
+                task.status = args.status
+            task.lp_save()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Add a script to assist in creating bulk bugs from the command line for bitesized tasks that the
cloud-init/curtin community can field.


To create a triaged, low-weight bug in cloud-init project with the bitesize tag:

cat > bug-descr  <<EOF
Here is my test bug description
EOF

lp-create-bug cloud-init --status Triaged --importance Low --title "test bug: please ignore/delete" --description @bug-descr
