### PR TITLE
new-upstream-snapshot: fix 'is_merge_commit'

### DIFF
--- a/scripts/new-upstream-snapshot
+++ b/scripts/new-upstream-snapshot
@@ -149,7 +149,7 @@ find_existing_remote() {
 
 is_merge_commit() {
     local commitish="$1" out="" num="" numlines=""
-    out=$(git show "--format=%P" "$commitish") ||
+    out=$(git show --no-patch "--format=%P" "$commitish") ||
         { error "failed git show --format=%P $commitish"; return 2; }
     numlines=$(echo "$out" | wc -l)
     [ "$numlines" -eq 1 ] || {


### PR DESCRIPTION
When merging  ssh-import-id from master at 5.8 to the ubuntu/debian
branch, it would cause merge conflict due to upstream maintaining a
debian/changelog.

The "fix merge commit" shell basically worked as designed, but
then when exiting the shell the 'git show --format=%P' would have changes.
We really just wanted to get the parent commits, not show diffs.

So... the fix is to just use '--no-patch'